### PR TITLE
fix: fix settings.loadLocale

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -14,7 +14,7 @@ class Settings {
             try {
                 const localeInLowerCase = locale.toLocaleLowerCase();
                 // https://github.com/iamkun/dayjs/issues/792#issuecomment-639961997
-                await import(`dayjs/locale/${localeInLowerCase}.js`);
+                await require(`dayjs/locale/${localeInLowerCase}.js`);
                 this.loadedLocales.add(localeInLowerCase);
             } catch (error) {
                 throw new Error(


### PR DESCRIPTION
`import` produces this output:
```
b = "dayjs/locale/" + localeInLowerCase + ".js”; 
require(b);
```
`require` produces this output:
```
require("dayjs/locale/" + localeInLowerCase + ".js”);
```

the first one ruines webpack