### PR TITLE
feat: support UTC timezone formatting

### DIFF
--- a/src/dateTime/dateTime.ts
+++ b/src/dateTime/dateTime.ts
@@ -18,7 +18,7 @@ export const createDateTime = (
 export const createUTCDateTime = (input?: DateTimeInput, format?: FormatInput) => {
     return (
         format ? dayjs.utc(input as ConfigType, format, STRICT) : dayjs.utc(input as ConfigType)
-    ) as DateTime;
+    ).tz('UTC') as DateTime; // setting .tz('UTC') allows having .format('L z') -> `02/02/2000 UTC`
 };
 
 /**

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -71,4 +71,13 @@ describe('Public API', () => {
 
         expect(timezone).toBe('Greenwich');
     });
+
+    it('utc timezone is supported', () => {
+        const dateWithTimezone = dateTime({
+            input: '2000-02-02T00:00:00.001Z',
+            timeZone: 'utc',
+        });
+
+        expect(dateWithTimezone.format('L z')).toBe('02/02/2000 UTC');
+    });
 });


### PR DESCRIPTION
hey folks, take a look at this PR

before this changes you weren't able to format date with `UTC` timezone specified, it was:
`dateTime({input: '02-02-2000', timeZone: 'utc'}).format('L z') // '02/02/2000 GMT'`