### PR TITLE
fix: revert support UTC formatting

### DIFF
--- a/src/dateTime/dateTime.test.ts
+++ b/src/dateTime/dateTime.test.ts
@@ -2,10 +2,15 @@ import MockDate from 'mockdate';
 import {DEFAULT_SYSTEM_DATE_FORMAT} from '../constants';
 import {settings} from '../settings';
 import {dateTime, isDateTime} from './dateTime';
+import type {DurationUnit} from '../typings';
 
 const MOCKED_DATE = '2021-08-07T12:10:00';
 
 MockDate.set(MOCKED_DATE);
+
+afterEach(() => {
+    MockDate.set(MOCKED_DATE);
+});
 
 describe('DateTime', () => {
     const TESTED_DATE_STRING = '2021-08-07';
@@ -73,6 +78,23 @@ describe('DateTime', () => {
             expect(date.second()).toEqual(10);
             expect(date.minute()).toEqual(10);
             expect(date.hour()).toEqual(10);
+        });
+
+        test.each<[{amount: string; unit: DurationUnit; durationUnit: DurationUnit}, string]>([
+            [{amount: '-24', unit: 'h', durationUnit: 'm'}, '2020-02-13T22:34:59.999Z'],
+            [{amount: '-300', unit: 's', durationUnit: 's'}, '2020-02-14T22:29:55.999Z'],
+        ])('endOf (%j)', ({amount, unit, durationUnit}, expected) => {
+            MockDate.set('2020-02-14T22:34:55.359Z');
+            const date = dateTime({timeZone: 'UTC'}).add(amount, unit).endOf(durationUnit);
+            expect(date.toISOString()).toEqual(expected);
+        });
+
+        test.each<[{amount: string; unit: DurationUnit; durationUnit: DurationUnit}, string]>([
+            [{amount: '+60', unit: 'm', durationUnit: 's'}, '2020-02-14T23:34:55.000Z'],
+        ])('startOf (%j)', ({amount, unit, durationUnit}, expected) => {
+            MockDate.set('2020-02-14T22:34:55.359Z');
+            const date = dateTime({timeZone: 'UTC'}).add(amount, unit).startOf(durationUnit);
+            expect(date.toISOString()).toEqual(expected);
         });
     });
 });

--- a/src/dateTime/dateTime.ts
+++ b/src/dateTime/dateTime.ts
@@ -18,7 +18,7 @@ export const createDateTime = (
 export const createUTCDateTime = (input?: DateTimeInput, format?: FormatInput) => {
     return (
         format ? dayjs.utc(input as ConfigType, format, STRICT) : dayjs.utc(input as ConfigType)
-    ).tz('UTC') as DateTime; // setting .tz('UTC') allows having .format('L z') -> `02/02/2000 UTC`
+    ) as DateTime;
 };
 
 /**

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -71,13 +71,4 @@ describe('Public API', () => {
 
         expect(timezone).toBe('Greenwich');
     });
-
-    it('utc timezone is supported', () => {
-        const dateWithTimezone = dateTime({
-            input: '2000-02-02T00:00:00.001Z',
-            timeZone: 'utc',
-        });
-
-        expect(dateWithTimezone.format('L z')).toBe('02/02/2000 UTC');
-    });
 });


### PR DESCRIPTION
Revert [this](https://github.com/gravity-ui/date-utils/commit/4a6f21f89fe49740bc972734db9df9e17ca99fd6) commit because it leads to incorrect behavior