### PR TITLE
fix(missing type): added export for DurationUnit type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,6 @@ export {dateTime, dateTimeUtc, isDateTime, expandFormat} from './dateTime';
 export {parse as defaultRelativeParse, isLikeRelative as defaultIsLikeRelative} from './datemath';
 export {dateTimeParse, isValid, isLikeRelative} from './parser';
 export {getTimeZonesList, guessUserTimeZone, isValidTimeZone, timeZoneOffset} from './timeZone';
-export type {DateTime, DateTimeInput, Duration, DurationInput} from './typings';
+export type {DateTime, DateTimeInput, Duration, DurationInput, DurationUnit} from './typings';
 export {UtcTimeZone, HTML5_INPUT_FORMATS} from './constants';
 export {duration, isDuration} from './duration';


### PR DESCRIPTION
For Datetime we expose methods like: add, subtract, diff. Those methods accept DurationUnit as an argument, but we don't export them from our package.