### PR TITLE
fix(dateTimeParse): parse 0 as valid dateTime

### DIFF
--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -54,6 +54,11 @@ describe('Parser', () => {
         expect(Boolean(date)).toEqual(false);
     });
 
+    it('should return DateTime in case of 0 input arg', () => {
+        const date = dateTimeParse(0)?.toISOString();
+        expect(date).toEqual('1970-01-01T00:00:00.000Z');
+    });
+
     test.each<[string | undefined, string]>([
         ['ru', '07 авг. 2021'],
         ['en', '07 Aug 2021'],

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -46,7 +46,7 @@ export const dateTimeParse: DateTimeParser<DateTimeOptionsWhenParsing> = (
     input,
     options,
 ): DateTime | undefined => {
-    if (!input) {
+    if (input === undefined) {
         return undefined;
     }
 


### PR DESCRIPTION
Closes #73 