### PR TITLE
feat(parseDateString): parse european date format

### DIFF
--- a/src/dateTime/dateTime.test.ts
+++ b/src/dateTime/dateTime.test.ts
@@ -239,5 +239,33 @@ describe('DateTime', () => {
                 }).toISOString(),
             ).toBe('0002-01-01T00:00:00.000Z');
         });
+
+        describe('European date format parsing', () => {
+            test.each<[string, [number, number, number, number, number, number, number]]>([
+                ['13.05.1997', [1997, 4, 13, 0, 0, 0, 0]], // dot
+                ['13/05/1997', [1997, 4, 13, 0, 0, 0, 0]], // slash
+                ['13-05-1997', [1997, 4, 13, 0, 0, 0, 0]], // dash
+                ['13 05 1997', [1997, 4, 13, 0, 0, 0, 0]], // space
+                ['13.05.1997 14:30', [1997, 4, 13, 14, 30, 0, 0]],
+                ['13.05.1997 14:30:45', [1997, 4, 13, 14, 30, 45, 0]],
+                ['13.05.1997 14:30:45.123', [1997, 4, 13, 14, 30, 45, 123]],
+                // Single digit day and month
+                ['1.5.1997', [1997, 4, 1, 0, 0, 0, 0]],
+                ['1.5.1997 23:59:59.999', [1997, 4, 1, 23, 59, 59, 999]],
+                ['1.5.1997 7:8:9.100', [1997, 4, 1, 7, 8, 9, 100]],
+            ])('should correctly parse European date format %s', (input, expected) => {
+                const date = dateTime({input, format: undefined});
+                expect([
+                    date.year(),
+                    date.month(),
+                    date.date(),
+                    date.hour(),
+                    date.minute(),
+                    date.second(),
+                    date.millisecond(),
+                ]).toEqual(expected);
+                expect(date.isValid()).toEqual(true);
+            });
+        });
     });
 });


### PR DESCRIPTION
### Enhanced European Date Format Support

**Problem**
Our users frequently need to copy and paste dates from various sources into applications using @gravity-ui/date-utils. Currently, the library doesn't support European date formats (DD.MM.YYYY), which are widely used in many regions. This creates friction in user workflows when they try to paste dates in formats like "13.05.1997" or "13/05/1997".

**Solution**

https://github.com/user-attachments/assets/f898185b-b6f2-4a5e-b920-b03fa4bc8e5d

This PR enhances the parseDateString function to properly recognize and parse European date formats with the following improvements:

- Support for multiple date separators (dots, slashes, dashes, spaces)
- Handling of dates with or without time components (e.g., "13.05.1997" and "13.05.1997 14:30:45")
- Support for single-digit day and month values (e.g., "1.5.1997")
- Test coverage