### PR TITLE
fix: clone settings locale data

### DIFF
--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -23,4 +23,13 @@ describe('settings', () => {
         settings.setLocale(LOCALE);
         expect(settings.getLocale()).toEqual(LOCALE);
     });
+
+    it('should clone locale data with function values', () => {
+        const localeData = settings.getLocaleData();
+        const nextLocaleData = settings.getLocaleData();
+
+        expect(typeof localeData.ordinal).toBe('function');
+        expect(localeData).not.toBe(nextLocaleData);
+        expect(localeData.formats).not.toBe(nextLocaleData.formats);
+    });
 });

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -25,6 +25,8 @@ describe('settings', () => {
     });
 
     it('should clone locale data with function values', () => {
+        settings.setLocale('en');
+
         const localeData = settings.getLocaleData();
         const nextLocaleData = settings.getLocaleData();
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -14,7 +14,9 @@ function cloneLocaleData<T>(value: T): T {
         return value.map((item) => cloneLocaleData(item)) as T;
     }
 
-    // Dayjs locale data is JSON-like with function fields; this is not a general structuredClone replacement.
+    // Dayjs locale data contains function fields such as ordinal.
+    // Clone array/plain-object containers so callers can safely mutate the result,
+    // while keeping locale functions callable by reference.
     return Object.fromEntries(
         Object.entries(value).map(([key, item]) => [key, cloneLocaleData(item)]),
     ) as T;

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -14,6 +14,7 @@ function cloneLocaleData<T>(value: T): T {
         return value.map((item) => cloneLocaleData(item)) as T;
     }
 
+    // Dayjs locale data is JSON-like with function fields; this is not a general structuredClone replacement.
     return Object.fromEntries(
         Object.entries(value).map(([key, item]) => [key, cloneLocaleData(item)]),
     ) as T;

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -5,6 +5,20 @@ import {normalizeTimeZone} from '../timeZone';
 import {localeLoaders} from './locales';
 import type {Locale, Parser, PublicSettings, UpdateLocaleConfig} from './types';
 
+function cloneLocaleData<T>(value: T): T {
+    if (!value || typeof value !== 'object') {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        return value.map((item) => cloneLocaleData(item)) as T;
+    }
+
+    return Object.fromEntries(
+        Object.entries(value).map(([key, item]) => [key, cloneLocaleData(item)]),
+    ) as T;
+}
+
 class Settings implements PublicSettings {
     // 'en' - preloaded locale in dayjs
     private loadedLocales = new Set(['en']);
@@ -50,7 +64,7 @@ class Settings implements PublicSettings {
             throw new Error('There is something really wrong happening. Locale data is absent.');
         }
 
-        return structuredClone(localeObject) as Locale;
+        return cloneLocaleData(localeObject) as Locale;
     }
 
     setLocale(locale: string) {


### PR DESCRIPTION
## What changed

`settings.getLocaleData()` now clones dayjs locale data with a small internal clone helper instead of `structuredClone`.

The helper keeps function values intact while still returning a detached copy for plain objects and arrays.

## Why

`dayjs.Ls[locale]` can contain functions, for example `ordinal`. `structuredClone` cannot clone functions and throws `DataCloneError` in browsers and Node:

```ts
import {settings} from '@gravity-ui/date-utils';

settings.getLocaleData(); // DataCloneError in 2.7.0
```

This surfaced in consumers that render date field/date picker components: date format expansion calls `getLocaleData()`, which crashes during render.

<img width="1483" height="819" alt="image" src="https://github.com/user-attachments/assets/3dfc800c-1053-4bce-ad17-09ed02cbfee8" />


## Tests

- `npm test -- settings`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm test`
- `npm run build`
